### PR TITLE
Updated types & queries with new UserStats data type

### DIFF
--- a/src/components/ServiceDetail.tsx
+++ b/src/components/ServiceDetail.tsx
@@ -68,7 +68,7 @@ function ServiceDetail({ service }: { service: IService }) {
                 <strong>Employer rating:</strong>
                 <Stars
                   rating={Number(service.buyer.rating)}
-                  numReviews={service.buyer.numReviews}
+                  numReviews={service.buyer.userStats.numReceivedReviews}
                 />
               </div>
               <p className='text-sm text-gray-500 mt-4'>

--- a/src/components/Stars.tsx
+++ b/src/components/Stars.tsx
@@ -1,4 +1,4 @@
-function Stars({ rating, numReviews }: { rating: number; numReviews: string }) {
+function Stars({ rating, numReviews }: { rating: number; numReviews: number }) {
   return (
     <div className='flex items-center mt-2.5 mb-5'>
       {[...Array(5)].map((_, i) => (
@@ -17,7 +17,7 @@ function Stars({ rating, numReviews }: { rating: number; numReviews: string }) {
         {rating}/5
       </span>
       <span className='text-xs text-gray-400'>
-        {numReviews} review{parseInt(numReviews) > 1 ? 's' : ''}
+        {numReviews} review{numReviews > 1 ? 's' : ''}
       </span>
     </div>
   );

--- a/src/components/UserDetail.tsx
+++ b/src/components/UserDetail.tsx
@@ -33,7 +33,7 @@ function UserDetail({ user }: { user: IUser }) {
             </div>
           </div>
         </div>
-        <Stars rating={Number(user.rating)} numReviews={user.numReviews} />
+        <Stars rating={Number(user.rating)} numReviews={user.userStats.numReceivedReviews} />
       </div>
       <div className=' border-t border-gray-100 pt-4 w-full'>
         {userDescription?.name && (

--- a/src/components/UserItem.tsx
+++ b/src/components/UserItem.tsx
@@ -29,7 +29,7 @@ function UserItem({ user }: { user: IUser }) {
             </div>
           </div>
         </div>
-        <Stars rating={Number(user.rating)} numReviews={user.numReviews} />
+        <Stars rating={Number(user.rating)} numReviews={user.userStats.numReceivedReviews} />
 
         <div className='flex flex-row gap-4 justify-end items-center'>
           <NavLink

--- a/src/queries/proposals.ts
+++ b/src/queries/proposals.ts
@@ -32,7 +32,9 @@ export const getAllProposalsByServiceId = (id: string): Promise<any> => {
           address
           cid
           rating
-          numReviews
+          userStats {
+            numReceivedReviews
+          }
         }
         description {
           id

--- a/src/queries/services.ts
+++ b/src/queries/services.ts
@@ -24,7 +24,9 @@ const serviceQueryFields = `
     handle
     address
     rating
-    numReviews
+    userStats {
+      numReceivedReviews
+    }
   }
   seller {
     id

--- a/src/queries/users.ts
+++ b/src/queries/users.ts
@@ -16,7 +16,9 @@ export const getUsers = (
         id
         address
         handle
-        numReviews
+        userStats {
+          numReceivedReviews
+        }
         rating
       }
     }
@@ -32,7 +34,9 @@ export const getUserById = (id: string): Promise<any> => {
         address
         handle
         rating
-        numReviews
+        userStats {
+          numReceivedReviews
+        }
         updatedAt
         createdAt
         description {
@@ -62,7 +66,9 @@ export const getUserByAddress = (address: string): Promise<any> => {
         address
         handle
         rating
-        numReviews
+        userStats {
+          numReceivedReviews
+        }
         updatedAt
         createdAt
         description {

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,8 +6,8 @@ export type IUser = {
   handle: string;
   address: string;
   rating: string;
-  numReviews: string;
   description?: IUserDetails;
+  userStats: IUserStats;
 };
 
 export type IUserDetails = {
@@ -18,6 +18,15 @@ export type IUserDetails = {
   video_url?: string;
   about: string;
   skills_raw: string;
+};
+
+export type IUserStats = {
+  numReceivedReviews: number;
+  numGivenReviews: number;
+  numCreatedServices: number;
+  numFinishedServices: number;
+  numCreatedProposals: number;
+  numFinishedProposals: number;
 };
 
 export type IAccount = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,9 +24,9 @@ export type IUserStats = {
   numReceivedReviews: number;
   numGivenReviews: number;
   numCreatedServices: number;
-  numFinishedServices: number;
+  numFinishedServicesAsBuyer: number;
   numCreatedProposals: number;
-  numFinishedProposals: number;
+  numFinishedServicesAsSeller: number;
 };
 
 export type IAccount = {


### PR DESCRIPTION
 **/!\ Breaking Changes /!\** 

The param "numReviews" representing the number of received reviews, available in the IUser type, will now be available in the 
new type :IUserStats under the "numReceivedReviews" param.

This new type can be found in the IUser type and includes the following fields:

type IUserStats {
  numReceivedReviews: number ===> number of reviews user has received
  numGivenReviews: number ===> number of reviews user has given
  numCreatedServices: number ===> number of services user has created
  numFinishedServices: number ===> number of services user has finished
  numCreatedProposals: number ===> number of proposals user has created
  numFinishedProposals: number ===> number of proposals user has finished
}

The denomination of the enum types for ServiceStatus have also been changed to fit the ones found in the TalentLayerServiceRegistry.sol smart contract:

They are now: 

enum ServiceStatus {
  Opened,
  Confirmed,
  Finished,
  Cancelled,
  Uncompleted
}